### PR TITLE
Added key prop to <path> in Line render()

### DIFF
--- a/src/components/line.jsx
+++ b/src/components/line.jsx
@@ -32,14 +32,15 @@ export default class Line extends Component {
     return (
       <g>
         {
-          dataset.map((line) => {
+          dataset.map((line, index) => {
             return (
               <path
                 stroke={line.color}
                 fill="none"
                 className={`${lineClassName} line`}
                 d={that._setAxes(line.data)}
-                style={line.style}/>
+                style={line.style}
+                key={index}/>
             )
           })
         }


### PR DESCRIPTION
Added key prop to the path component to suppress the React-warning:

"Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Line`. See https://fb.me/react-warning-keys for more information"
