### PR TITLE
add key prop to mkPie() wedge rendering in Pie

### DIFF
--- a/src/components/pie.jsx
+++ b/src/components/pie.jsx
@@ -111,10 +111,9 @@ export default class Pie extends Component {
             }
 
             return (
-              <g>
-                <path 
-                  key={i}
-                  d={arc(slice)} 
+              <g key={i}>
+                <path
+                  d={arc(slice)}
                   style={{fill: slice.data.color, stroke: '#FFF', ...slice.data.style}}
                   onMouseOut={that.triggerOut.bind(this, slice)}
                   onMouseOver={that.triggerOver.bind(this, slice)}


### PR DESCRIPTION
Similar to #3, this adds a key prop to pie charts to get rid of the warning it currently throws.
