### PR TITLE
Propagate labels to Axis components

### DIFF
--- a/src/chart.jsx
+++ b/src/chart.jsx
@@ -53,6 +53,8 @@ export default class ChartSvg extends Component {
       xBandPaddingOuter,
       yBandPaddingInner,
       yBandPaddingOuter,
+      xLabel,
+      yLabel,
       stack,
       data,
       svgClassName,
@@ -114,6 +116,8 @@ export default class ChartSvg extends Component {
           yTickFormat: yTickFormat,
           xTicks: xTicks,
           yTicks: yTicks,
+          xLabel: xLabel,
+          yLabel: yLabel,
           data: data,
           x: x,
           y: y


### PR DESCRIPTION
Currently the x/y labels from a `<Chart >` do not seem to be passed to a `<YAxis>`.

I've stepped through and found that something like:

``` jsx
<LineChart
              title='Training time vs plan'
              width={800} height={300}
              data={d3data}
              chartSeries={chartSeries}
              x={x}
              yLabel=' Time (Minutes)'
              xLabel='Plan week'
              margins={{top: 20, right: 50, bottom: 20, left: 100}}
            />
```

Does not lead to the labels being shown (but other x/y properties such as domain are passed down).
