### PR TITLE
Silence unique-key errors

### DIFF
--- a/src/components/area.jsx
+++ b/src/components/area.jsx
@@ -32,13 +32,14 @@ export default class Area extends Component {
     return (
       <g>
         {
-          dataset.map((area) => {
+          dataset.map((area, i) => {
             return (
               <path
                 className={`${areaClassName} area`}
                 fill={area.color}
                 d={that._setAxes(area.data)}
                 style={area.style}
+                key={i}
                 />
             )
           })

--- a/src/components/bar.jsx
+++ b/src/components/bar.jsx
@@ -52,7 +52,7 @@ export default class Bar extends Component {
     return (
       <g>
         {
-          dataset.data.map((bar) => {
+          dataset.data.map((bar, i) => {
             return (
               <rect 
                 className={`${barClassName} bar`}
@@ -64,6 +64,7 @@ export default class Bar extends Component {
                 style={Object.assign({}, dataset.style, bar._style)}
                 onMouseOut={that.triggerOut.bind(this, bar)}
                 onMouseOver={that.triggerOver.bind(this, bar)}
+                key={i}
                 />
             )
           })


### PR DESCRIPTION
Silences unique-key errors for the bar and area shapes:

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Area`
```

and

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Bar`
```

Similar solution to #12 .
