### PR TITLE
fixed area stack render on node.js

### DIFF
--- a/src/components/area_stack.jsx
+++ b/src/components/area_stack.jsx
@@ -6,6 +6,7 @@ import {
   PropTypes,
 } from 'react';
 
+import d3 from 'd3';
 import D3Shape from 'd3-shape'
 import CommonProps from '../commonProps';
 import {series} from '../utils/series';


### PR DESCRIPTION
"_setStack" method uses a d3 that has not been imported before
