### PR TITLE
fixing peerDependency to work with React 15+

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "webpack-hot-middleware": "^2.9.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": ">=0.14.7",
+    "react-dom": ">=0.14.7"
   },
   "dependencies": {
     "d3": "^3.5.6",


### PR DESCRIPTION
Yet another PR that's probably gonna get forgotten here, just like react-d3/react-d3-basic#43
